### PR TITLE
Add PYTHONPATH so pytest sees package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,3 +10,5 @@ jobs:
           python-version: '3.x'
       - run: python -m pip install -U pytest
       - run: pytest -q
+        env:
+          PYTHONPATH: ${{ github.workspace }}


### PR DESCRIPTION
## Summary
- set PYTHONPATH to the repository root during pytest so quickhash.py imports resolve

## Testing
- not run (rely on CI)